### PR TITLE
Update Makefile

### DIFF
--- a/packaging/Darwin/Makefile
+++ b/packaging/Darwin/Makefile
@@ -18,7 +18,7 @@ plug:
 	echo $(PLUGS)
 
 portable:
-	rm -Rf bin;mkdir -p bin ;for i in $(BINS); do cp ../../build/$$i bin/ ;./mkport.sh ./bin/$$i; done; \
+	rm -Rf bin;mkdir -p bin ;for i in $(BINS); do cp ../../build/$$i bin/; mkdir -p bin/lib; ./mkport.sh ./bin/$$i; done; \
 	mkdir -p bin/lib ;for i in $(LIBS); do cp ../../libov/tascar/libtascar/build/$$i bin/lib/ ;./mkport.sh ./bin/lib/$$i; done; \
 	for i in $(PLUGS); do cp ../../libov/tascar/plugins/build/$$i bin/lib/ ;./mkport.sh ./bin/lib/$$i ./bin/lib/; done; \
 	mv bin/ovbox bin/ovbox.bin; \


### PR DESCRIPTION
`mkport.sh` would fail if `bin/lib` doesn't exist (with this error: `realpath: /Users/tfoerg/dev/ov-client/packaging/Darwin/bin/lib: No such file or directory`)